### PR TITLE
Refactor code

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="www.thecodemonks.techbytes">
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 

--- a/app/src/main/java/www/thecodemonks/techbytes/ui/adapter/NewsAdapter.kt
+++ b/app/src/main/java/www/thecodemonks/techbytes/ui/adapter/NewsAdapter.kt
@@ -32,7 +32,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import coil.api.load
+import coil.load
 import coil.transform.RoundedCornersTransformation
 import www.thecodemonks.techbytes.databinding.ItemPostArticleBinding
 import www.thecodemonks.techbytes.model.Article
@@ -52,7 +52,8 @@ class NewsAdapter : RecyclerView.Adapter<NewsAdapter.NewsVH>() {
 
     val differ = AsyncListDiffer(this, differCallback)
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NewsVH {
-        val binding = ItemPostArticleBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val binding =
+            ItemPostArticleBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return NewsVH(binding)
     }
 
@@ -65,7 +66,7 @@ class NewsAdapter : RecyclerView.Adapter<NewsAdapter.NewsVH>() {
         val item = differ.currentList[position]
         holder.binding.apply {
 
-            if (item.title.isNullOrBlank() || item.description.isNullOrBlank() || item.image.isNullOrBlank()) {
+            if (item.title.isBlank() || item.description.isNullOrBlank() || item.image.isNullOrBlank()) {
 
                 itemArticleTitle.visibility = View.GONE
                 itemPostDescription.visibility = View.GONE

--- a/app/src/main/java/www/thecodemonks/techbytes/ui/details/ArticleDetailsFragment.kt
+++ b/app/src/main/java/www/thecodemonks/techbytes/ui/details/ArticleDetailsFragment.kt
@@ -43,7 +43,7 @@ import www.thecodemonks.techbytes.utils.Constants
 
 class ArticleDetailsFragment : Fragment(R.layout.fragment_article_details) {
     private lateinit var viewModel: ArticleViewModel
-    val args: ArticleDetailsFragmentArgs by navArgs()
+    private val args: ArticleDetailsFragmentArgs by navArgs()
     private var completeUrl: String? = null
     private lateinit var _binding: FragmentArticleDetailsBinding
     private val binding get() = _binding

--- a/app/src/main/java/www/thecodemonks/techbytes/utils/Animations.kt
+++ b/app/src/main/java/www/thecodemonks/techbytes/utils/Animations.kt
@@ -61,11 +61,11 @@ object Animations {
             }
         })
 
-        val animatorSet = AnimatorSet();
+        val animatorSet = AnimatorSet()
         animatorSet.playSequentially(
             fadeOut,
             fadeIn
-        );
+        )
         animatorSet.start()
 
     }

--- a/app/src/main/java/www/thecodemonks/techbytes/utils/NetworkManager.kt
+++ b/app/src/main/java/www/thecodemonks/techbytes/utils/NetworkManager.kt
@@ -56,9 +56,7 @@ class NetworkManager(context: Context) : ConnectivityManager.NetworkCallback() {
             connectivityManager.registerNetworkCallbackCompact(this)
             val connectionStatus = connectivityManager.allNetworks.any { network ->
                 val networkCapabilities = connectivityManager.getNetworkCapabilities(network)
-                val isConnected =
-                    networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
-                return@any isConnected
+                return@any networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
             }
             _connectionStatusLiveData.value = connectionStatus
         }


### PR DESCRIPTION
Hi @Spikeysanju this PR fixes the following points:

1. Call on not-null type may be reduced (NewsAdapter.kt 68)
2. Replace deprecated `coil.api.load` with `coil.load`. (NewsAdapter.kt 80)
3. Redundant semicolon (Animations.kt 64, 68)
4. Variable used only in following return and should be inlined (NetworkManager.kt 58)
5. Property 'args' could be private (ArticleDetailFragment.kt 46)
6. When calling intent.resolveActivity (ArticleDetailsFragment.kt 115) consider add the `<queries>` element, apps can define the set of other packages that they can access. https://developer.android.com/about/versions/11/privacy/package-visibility